### PR TITLE
Var tournament players

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ install:
 # command to run tests
 script:
   - nosetests
+  - ./sample_tournament.sh
+  - ./sample.sh

--- a/playgame.py
+++ b/playgame.py
@@ -29,7 +29,7 @@ def main(argv):
     args = parse_args(argv)
     prep_logger(args.log_dir, args.verbose, args.log_stderr, len(args.players))
     args.players = validate_players(args.players)
-    if args.is_tournament:
+    if args.command is 'tournament':
         run_tournament(args)
     else:
         run_one_game(args)
@@ -152,7 +152,7 @@ def parse_args(args):
                         help = 'log errors to file')
 
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(help = 'commands',
+    subparsers = parser.add_subparsers(help = usage,
                         dest = 'command')
 
     #single game-specific arguments
@@ -195,7 +195,7 @@ class HanabiGame:
             logger.debug('Disclosures left: {disclosures}'.format(disclosures = info['disclosures']))
             logger.debug('Mistakes left: {mistakes}'.format(mistakes = info['mistakes_left']))
 
-        player_details = "Game with {players}".format(players = map(lambda(player): player.__class__.__name__, self.players))
+        player_details = 'Game with {players}'.format(players = map(lambda(player): player.__class__.__name__, self.players))
         logger.info(player_details)
 
         while not self.table.is_game_over():

--- a/playgame.py
+++ b/playgame.py
@@ -127,21 +127,35 @@ def parse_args():
 
     #Optional arguments
     parser.add_argument('-s', '--seed',
-                        default = int(round(time.time()*1000)), type = int,
+                        default = int(round(time.time()*1000)),
+                        type = int,
                         help = 'a specific seed for shuffling the deck')
-    parser.add_argument('-r', '--variant', type = int, choices = [1, 2, 3],
+    parser.add_argument('-r', '--variant',
+                        type = int,
+                        choices = [1, 2, 3],
                         default = 0,
                         dest = 'variant',
                         help = 'play the selected variant')
-    parser.add_argument('-t', '--tournament', dest = 'is_tournament',
+    parser.add_argument('-t', '--tournament',
+                        dest = 'is_tournament',
                         action = 'store_true',
                         help = 'run 2 player games for all combinations of players (no repeats)')
-    parser.add_argument('-v', '--verbose', dest = 'verbose',
+    parser.add_argument('-n', '--players_per_game',
+                        dest = 'per_round',
+                        type = int,
+                        choices = [2, 3, 4, 5],
+                        default = 2,
+                        help = 'number of players per game in the tournament')
+    parser.add_argument('-v', '--verbose',
+                        dest = 'verbose',
                         action = 'store_true',
                         help = 'log moves and game state as game is played')
-    parser.add_argument('-l', '--log_dir', dest = 'log_dir', default = None,
+    parser.add_argument('-l', '--log_dir',
+                        dest = 'log_dir',
+                        default = None,
                         help = 'save logs to file')
-    parser.add_argument('-e', '--log_stderr', dest = 'log_stderr',
+    parser.add_argument('-e', '--log_stderr',
+                        dest = 'log_stderr',
                         help = 'log errors to file')
 
     return parser.parse_args()

--- a/playgame.py
+++ b/playgame.py
@@ -152,7 +152,8 @@ def parse_args(args):
                         help = 'log errors to file')
 
     parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(help = 'commands',
+                        dest = 'command')
 
     #single game-specific arguments
     subparsers.add_parser('single',

--- a/playgame.py
+++ b/playgame.py
@@ -160,7 +160,7 @@ def parse_args(args):
                         choices = [2, 3, 4, 5],
                         default = 2,
                         help = 'number of players per game in the tournament')
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 def prep_players(player_names):
     return map(lambda player_name: locate(player_name)(), player_names)

--- a/playgame.py
+++ b/playgame.py
@@ -121,42 +121,49 @@ def prep_logger(log_dir, verbose, log_stderr, count):
 def parse_args(args):
     usage = 'plays games of Hanabi using the listed players'
 
-    parser = argparse.ArgumentParser(description = usage)
+    parent_parser = argparse.ArgumentParser(add_help=False)
 
     #Positional arguments
-    parser.add_argument('players',
+    parent_parser.add_argument('players',
                         nargs = '+',
                         help = 'the players that will play Hanabi. First 5 will play unless in tournament mode')
 
     #Optional arguments
-    parser.add_argument('-s', '--seed',
+    parent_parser.add_argument('-s', '--seed',
                         default = int(round(time.time()*1000)),
                         type = int,
                         help = 'a specific seed for shuffling the deck')
-    parser.add_argument('-r', '--variant',
+    parent_parser.add_argument('-r', '--variant',
                         type = int,
                         choices = [1, 2, 3],
                         default = 0,
                         dest = 'variant',
                         help = 'play the selected variant')
-    parser.add_argument('-v', '--verbose',
+    parent_parser.add_argument('-v', '--verbose',
                         dest = 'verbose',
                         action = 'store_true',
                         help = 'log moves and game state as game is played')
-    parser.add_argument('-l', '--log_dir',
+    parent_parser.add_argument('-l', '--log_dir',
                         dest = 'log_dir',
                         default = None,
                         help = 'save logs to file')
-    parser.add_argument('-e', '--log_stderr',
+    parent_parser.add_argument('-e', '--log_stderr',
                         dest = 'log_stderr',
                         help = 'log errors to file')
 
-    tournament_group = parser.add_argument_group('tournament arguments')
-    tournament_group.add_argument('-t', '--tournament',
-                        dest = 'is_tournament',
-                        action = 'store_true',
-                        help = 'run 2 player games for all combinations of players (no repeats)')
-    tournament_group.add_argument('-p', '--players_per_game',
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+
+    #single game-specific arguments
+    subparsers.add_parser('single',
+                        help = 'run a single game of Hanabi',
+                        parents = [parent_parser])
+
+    #tournament mode-specific arguments
+    tournament = subparsers.add_parser('tournament',
+                        parents = [parent_parser],
+                        help = 'run games for all combinations of players (no repeats)')
+    tournament.add_argument('-p', '--players_per_game',
                         dest = 'per_round',
                         type = int,
                         choices = [2, 3, 4, 5],

--- a/sample.sh
+++ b/sample.sh
@@ -1,1 +1,1 @@
-python playgame.py "ai.example_discarder.Discarder" "ai.example_discarder.Discarder" --verbose --log_dir "results/results.txt" --log_stderr "results/errors.txt"
+python playgame.py "single" "ai.example_discarder.Discarder" "ai.example_discarder.Discarder" --verbose --log_dir "results/results.txt" --log_stderr "results/errors.txt"

--- a/sample.sh
+++ b/sample.sh
@@ -1,1 +1,1 @@
-python playgame.py "ai.example_discarder.Discarder" "ai.example_discarder.Discarder" --verbose --log_dir "results/a/b/c/results.txt" --log_stderr "results/errors.txt"
+python playgame.py "ai.example_discarder.Discarder" "ai.example_discarder.Discarder" --verbose --log_dir "results/results.txt" --log_stderr "results/errors.txt"

--- a/sample_tournament.sh
+++ b/sample_tournament.sh
@@ -1,1 +1,1 @@
-python playgame.py "ai.example_discarder.Discarder" "ai.example_discarder.Discarder" "ai.example_discarder.Discarder" --log_dir "results/tournament_results.txt" --log_stderr "results/tournament_errors.txt" --tournament
+python playgame.py "tournament" "ai.example_discarder.Discarder" "ai.example_discarder.Discarder" "ai.example_discarder.Discarder" --log_dir "results/tournament_results.txt" --log_stderr "results/tournament_errors.txt"

--- a/tools/tests/playgame_tests.py
+++ b/tools/tests/playgame_tests.py
@@ -9,52 +9,51 @@ from ai.hanabi_player import HanabiPlayer
 class PlayGameparserTests(unittest.TestCase):
 
     def test_game_simple(self):
-        args = ["Discarder"]
+        args = ["single", "Discarder"]
         parsed = playgame.parse_args(args)
+        print(parsed)
         self.assertEqual(1, len(parsed.players))
         self.assertEquals(0, parsed.variant)
         self.assertFalse(parsed.verbose)
         self.assertEquals(None, parsed.log_dir)
         self.assertEquals(None, parsed.log_stderr)
-        self.assertFalse(parsed.is_tournament)
-        #default even if not in tournament mode. Unused, but icky
-        self.assertEquals(2, parsed.per_round)
+        self.assertEquals(parsed.command, 'single')
 
     def test_game_variant(self):
-        args = ["Discarder", '-r', '3']
+        args = ["single", "Discarder", '-r', '3']
         parsed = playgame.parse_args(args)
         self.assertEquals(3, parsed.variant)
 
     def test_game_verbose(self):
-        args = ["Discarder", '-v']
+        args = ["single", "Discarder", '-v']
         parsed = playgame.parse_args(args)
         self.assertTrue(parsed.verbose)
 
     def test_game_log_dir(self):
-        args = ["Discarder", '-l', 'results.txt']
+        args = ["single", "Discarder", '-l', 'results.txt']
         parsed = playgame.parse_args(args)
         self.assertEquals("results.txt", parsed.log_dir)
 
     def test_game_log_stderr(self):
-        args = ["Discarder", '-e', 'errors.txt']
+        args = ["single", "Discarder", '-e', 'errors.txt']
         parsed = playgame.parse_args(args)
         self.assertEquals("errors.txt", parsed.log_stderr)
 
     def test_game_seed(self):
-        args = ["Discarder", '-s', '76']
+        args = ["single", "Discarder", '-s', '76']
         parsed = playgame.parse_args(args)
         self.assertEquals(76, parsed.seed)
 
     def test_tournament_simple(self):
-        args = ["Discarder", '-t']
+        args = ["tournament", "Discarder",]
         parsed = playgame.parse_args(args)
-        self.assertTrue(parsed.is_tournament)
         self.assertEquals(2, parsed.per_round)
+        self.assertEquals(parsed.command, 'tournament')
 
     def test_tournament_per_round(self):
-        args = ["Discarder", '-t', '-p', '4']
+        args = ["tournament", "Discarder", '-p', '4']
         parsed = playgame.parse_args(args)
-        self.assertTrue(parsed.is_tournament)
+        self.assertEquals(parsed.command, 'tournament')
         self.assertEquals(4, parsed.per_round)
 
 class MockBadPlayer:

--- a/tools/tests/playgame_tests.py
+++ b/tools/tests/playgame_tests.py
@@ -1,5 +1,6 @@
 import playgame
 import unittest
+from sets import Set
 from playgame import HanabiGame
 from argparse import Namespace
 from tools.hanabi_deck import HanabiVariant
@@ -78,7 +79,7 @@ class PlayGameTests(unittest.TestCase):
             'D' : 50,
             'E' : 20
         }
-        disqualified = []
+        disqualified = Set()
         playgame.disqualify_player(disqualified, scores, 'D')
         self.assertTrue('D' in disqualified)
         self.assertEqual(1, len(disqualified))
@@ -91,7 +92,7 @@ class PlayGameTests(unittest.TestCase):
             'D' : 50,
             'E' : 20
         }
-        disqualified = []
+        disqualified = Set()
         playgame.disqualify_player(disqualified, scores, 'C')
         self.assertTrue('C' in disqualified)
         self.assertEqual(1, len(disqualified))
@@ -104,7 +105,7 @@ class PlayGameTests(unittest.TestCase):
             'D' : 50,
             'E' : 20
         }
-        disqualified = []
+        disqualified = Set()
         playgame.disqualify_player(disqualified, scores, 'A')
         playgame.disqualify_player(disqualified, scores, 'E')
         self.assertTrue('E', 'A' in disqualified)

--- a/tools/tests/playgame_tests.py
+++ b/tools/tests/playgame_tests.py
@@ -9,7 +9,7 @@ from ai.hanabi_player import HanabiPlayer
 class PlayGameparserTests(unittest.TestCase):
 
     def test_game_simple(self):
-        args = ["single", "Discarder"]
+        args = ['single', 'Discarder']
         parsed = playgame.parse_args(args)
         print(parsed)
         self.assertEqual(1, len(parsed.players))
@@ -20,38 +20,38 @@ class PlayGameparserTests(unittest.TestCase):
         self.assertEquals(parsed.command, 'single')
 
     def test_game_variant(self):
-        args = ["single", "Discarder", '-r', '3']
+        args = ['single', 'Discarder', '-r', '3']
         parsed = playgame.parse_args(args)
         self.assertEquals(3, parsed.variant)
 
     def test_game_verbose(self):
-        args = ["single", "Discarder", '-v']
+        args = ['single', 'Discarder', '-v']
         parsed = playgame.parse_args(args)
         self.assertTrue(parsed.verbose)
 
     def test_game_log_dir(self):
-        args = ["single", "Discarder", '-l', 'results.txt']
+        args = ['single', 'Discarder', '-l', 'results.txt']
         parsed = playgame.parse_args(args)
-        self.assertEquals("results.txt", parsed.log_dir)
+        self.assertEquals('results.txt', parsed.log_dir)
 
     def test_game_log_stderr(self):
-        args = ["single", "Discarder", '-e', 'errors.txt']
+        args = ['single', 'Discarder', '-e', 'errors.txt']
         parsed = playgame.parse_args(args)
-        self.assertEquals("errors.txt", parsed.log_stderr)
+        self.assertEquals('errors.txt', parsed.log_stderr)
 
     def test_game_seed(self):
-        args = ["single", "Discarder", '-s', '76']
+        args = ['single', 'Discarder', '-s', '76']
         parsed = playgame.parse_args(args)
         self.assertEquals(76, parsed.seed)
 
     def test_tournament_simple(self):
-        args = ["tournament", "Discarder",]
+        args = ['tournament', 'Discarder',]
         parsed = playgame.parse_args(args)
         self.assertEquals(2, parsed.per_round)
         self.assertEquals(parsed.command, 'tournament')
 
     def test_tournament_per_round(self):
-        args = ["tournament", "Discarder", '-p', '4']
+        args = ['tournament', 'Discarder', '-p', '4']
         parsed = playgame.parse_args(args)
         self.assertEquals(parsed.command, 'tournament')
         self.assertEquals(4, parsed.per_round)

--- a/tools/tests/playgame_tests.py
+++ b/tools/tests/playgame_tests.py
@@ -5,6 +5,57 @@ from argparse import Namespace
 from tools.hanabi_deck import HanabiVariant
 from ai.hanabi_player import HanabiPlayer
 
+class PlayGameparserTests(unittest.TestCase):
+
+    def test_game_simple(self):
+        args = ["Discarder"]
+        parsed = playgame.parse_args(args)
+        self.assertEqual(1, len(parsed.players))
+        self.assertEquals(0, parsed.variant)
+        self.assertFalse(parsed.verbose)
+        self.assertEquals(None, parsed.log_dir)
+        self.assertEquals(None, parsed.log_stderr)
+        self.assertFalse(parsed.is_tournament)
+        #default even if not in tournament mode. Unused, but icky
+        self.assertEquals(2, parsed.per_round)
+
+    def test_game_variant(self):
+        args = ["Discarder", '-r', '3']
+        parsed = playgame.parse_args(args)
+        self.assertEquals(3, parsed.variant)
+
+    def test_game_verbose(self):
+        args = ["Discarder", '-v']
+        parsed = playgame.parse_args(args)
+        self.assertTrue(parsed.verbose)
+
+    def test_game_log_dir(self):
+        args = ["Discarder", '-l', 'results.txt']
+        parsed = playgame.parse_args(args)
+        self.assertEquals("results.txt", parsed.log_dir)
+
+    def test_game_log_stderr(self):
+        args = ["Discarder", '-e', 'errors.txt']
+        parsed = playgame.parse_args(args)
+        self.assertEquals("errors.txt", parsed.log_stderr)
+
+    def test_game_seed(self):
+        args = ["Discarder", '-s', '76']
+        parsed = playgame.parse_args(args)
+        self.assertEquals(76, parsed.seed)
+
+    def test_tournament_simple(self):
+        args = ["Discarder", '-t']
+        parsed = playgame.parse_args(args)
+        self.assertTrue(parsed.is_tournament)
+        self.assertEquals(2, parsed.per_round)
+
+    def test_tournament_per_round(self):
+        args = ["Discarder", '-t', '-p', '4']
+        parsed = playgame.parse_args(args)
+        self.assertTrue(parsed.is_tournament)
+        self.assertEquals(4, parsed.per_round)
+
 class MockBadPlayer:
     pass
 
@@ -62,12 +113,12 @@ class PlayGameTests(unittest.TestCase):
 
     def test_determine_winner_one_winner(self):
         results = {
-            'A' : [20, 2],
-            'B' : [22, 7],
-            'C' : [25, 25],
-            'D' : [25, 4],
-            'E' : [25, 1],
-            'F' : [1, 1]
+            'A' : {'mean': 20, 'variance': 2},
+            'B' : {'mean': 22, 'variance': 7},
+            'C' : {'mean': 25, 'variance': 25},
+            'D' : {'mean': 25, 'variance': 4},
+            'E' : {'mean': 25, 'variance': 1},
+            'F' : {'mean': 1, 'variance': 1}
         }
         winners = playgame.determine_winner(results)
         self.assertTrue('A' not in winners)
@@ -79,11 +130,11 @@ class PlayGameTests(unittest.TestCase):
 
     def test_determine_winner_tie(self):
         results = {
-            'A' : [20, 2],
-            'B' : [22, 7],
-            'C' : [25, 25],
-            'D' : [25, 4],
-            'E' : [25, 4]
+            'A' : {'mean': 20, 'variance': 2},
+            'B' : {'mean': 22, 'variance': 7},
+            'C' : {'mean': 25, 'variance': 25},
+            'D' : {'mean': 25, 'variance': 4},
+            'E' : {'mean': 25, 'variance': 4}
         }
         winners = playgame.determine_winner(results)
         self.assertTrue('A' not in winners)


### PR DESCRIPTION
Resolves #31
Adding an optional param to play with different number of players per round in a tournament. Can use the `-p` flag at the end of `sample_tournament.sh` to try it out
Also getting the parser arguments under test