### PR TITLE
The Great Dictionary Purge for do_turn. HanabiPlayers Now Return Actions, Not Dictionaries

### DIFF
--- a/ai/example_discarder.py
+++ b/ai/example_discarder.py
@@ -1,4 +1,5 @@
 import tools.hanabi_table as game
+import tools.hanabi_moves as moves
 from hanabi_player import HanabiPlayer
 
 #To create an AI for Hanabi, make a new class in the ai folder,
@@ -8,15 +9,10 @@ class Discarder(HanabiPlayer):
         pass
 
     def do_turn(self, player_index, game_info):
-        if game_info.can_discard():
-            return {
-                'play_type' : 'discard',
-                'card' : 0
-                }
+        if game_info["disclosures"] < game.NUM_DISCLOSURES:
+            return moves.HanabiDiscardAction(player_index, 0)
         else:
-            return {
-                'play_type':'disclose',
-                'player' : game_info.next_player(player_index),
-                'disclose_type' : 'rank',
-                'rank' : 1
-            }
+            return moves.HanabiDiscloseRankAction(player_index,
+                (player_index + 1) % game_info["num_players"],
+                0,
+                1)

--- a/ai/example_discarder.py
+++ b/ai/example_discarder.py
@@ -9,10 +9,9 @@ class Discarder(HanabiPlayer):
         pass
 
     def do_turn(self, player_index, game_info):
-        if game_info["disclosures"] < game.NUM_DISCLOSURES:
+        if game_info.disclosures < game.NUM_DISCLOSURES:
             return moves.HanabiDiscardAction(player_index, 0)
         else:
             return moves.HanabiDiscloseRankAction(player_index,
-                (player_index + 1) % game_info["num_players"],
-                0,
+                game_info.next_player(player_index),
                 1)

--- a/ai/hanabi_player.py
+++ b/ai/hanabi_player.py
@@ -17,11 +17,10 @@ class HanabiPlayer:
             "scored_cards": dictionary of highest scored card per pile. Uses first letter of a color as key (i.e. "R")
             "history": list of moves objects made throughout the game. All are defined in hanabi_moves.py
 
-        @return a dictionary of the command to do. Uses the following formatting:
-            {'play_type':'play', 'card':<number>}
-            {'play_type':'discard', 'card':<number>}
-            {'play_type':'disclose', 'player':<player_id>, 'disclose_type':'color', 'color':<color>}
-            {'play_type':'disclose', 'player':<player_id>, 'disclose_type':'rank', 'rank':<number>}
+        @return an Action of the command to do. The Actions are
+            HanabiPlayAction: plays a card
+            HanabiDiscardAction: discards a card
+            HanabiDiscloseColorAction: discloses a color to a specified player
+            HanabiDiscloseRankAction: discloses a rank to a specified player
         """
         pass
-        

--- a/playgame.py
+++ b/playgame.py
@@ -15,8 +15,8 @@ from sets import Set
 from logging.handlers import RotatingFileHandler
 from tools.hanabi_moves import (HanabiDiscardAction,
     HanabiPlayAction,
-    HanabiColorDiscloseAction,
-    HanabiRankDiscloseAction)
+    HanabiDiscloseColorAction,
+    HanabiDiscloseRankAction)
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -257,8 +257,8 @@ class HanabiGame:
 
     def is_valid_disclose_move(self, player_move):
         return (self.table.can_disclose() and
-            (HanabiColorDiscloseAction.can_parse_move(player_move) or
-            HanabiRankDiscloseAction.can_parse_move(player_move)))
+            (HanabiDiscloseColorAction.can_parse_move(player_move) or
+            HanabiDiscloseRankAction.can_parse_move(player_move)))
 
     def parse_turn(self, player_move):
         if not self.is_valid_move(player_move):

--- a/playgame.py
+++ b/playgame.py
@@ -230,7 +230,7 @@ class HanabiGame:
             info = self.table.info_for_player(self.current_player)
             player_move = player.do_turn(self.current_player, info)
             if player_move.is_valid(info):
-                self.make_move(player_move)
+                player_move.execute(self.table)
                 pretty_print_info(info)
                 logger.debug(str(player_move))
                 self.current_player = (self.current_player + 1) % self.table.num_players
@@ -242,20 +242,6 @@ class HanabiGame:
 
     def game_history(self):
         return map(lambda action: str(action), self.table.history)
-
-    def make_move(self, player_move):
-        if isinstance(player_move, moves.HanabiPlayAction):
-            return self.table.play_card(self.current_player, player_move.card)
-        elif isinstance(player_move, moves.HanabiDiscardAction):
-            return self.table.discard_card(self.current_player, player_move.card)
-        elif issubclass(player_move.__class__, moves.HanabiDiscloseAction):
-            return self.play_disclose(player_move)
-
-    def play_disclose(self, player_move):
-        if isinstance(player_move, moves.HanabiDiscloseColorAction):
-            return self.table.disclose_color(self.current_player, player_move.player_id, player_move.color)
-        elif isinstance(player_move, moves.HanabiDiscloseRankAction):
-            return self.table.disclose_rank(self.current_player, player_move.player_id, player_move.rank)
 
     def disqualify(self, player_move):
         logger.warning('Expected format for play card:')

--- a/playgame.py
+++ b/playgame.py
@@ -248,14 +248,14 @@ class HanabiGame:
             return self.table.play_card(self.current_player, player_move.card)
         elif isinstance(player_move, moves.HanabiDiscardAction):
             return self.table.discard_card(self.current_player, player_move.card)
-        elif issubclass(player_move, moves.HanabiDiscloseAction):
+        elif issubclass(player_move.__class__, moves.HanabiDiscloseAction):
             return self.play_disclose(player_move)
 
     def play_disclose(self, player_move):
         if isinstance(player_move, moves.HanabiDiscloseColorAction):
-            return self.table.disclose_color(self.current_player, player_move.player, player_move.color)
+            return self.table.disclose_color(self.current_player, player_move.player_id, player_move.color)
         elif isinstance(player_move, moves.HanabiDiscloseRankAction):
-            return self.table.disclose_rank(self.current_player, player_move.player, player_move.rank)
+            return self.table.disclose_rank(self.current_player, player_move.player_id, player_move.rank)
 
     def disqualify(self, player_move):
         logger.warning('Expected format for play card:')

--- a/playgame.py
+++ b/playgame.py
@@ -13,10 +13,7 @@ import numpy
 import matplotlib.pyplot as plt
 from sets import Set
 from logging.handlers import RotatingFileHandler
-from tools.hanabi_moves import (HanabiDiscardAction,
-    HanabiPlayAction,
-    HanabiDiscloseColorAction,
-    HanabiDiscloseRankAction)
+import tools.hanabi_moves as moves
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -232,10 +229,13 @@ class HanabiGame:
             player = self.players[self.current_player]
             info = self.table.info_for_player(self.current_player)
             player_move = player.do_turn(self.current_player, info)
-            move = self.parse_turn(player_move)
-            pretty_print_info(info)
-            logger.debug(str(move))
-            self.current_player = (self.current_player + 1) % self.table.num_players
+            if player_move.is_valid(info):
+                self.make_move(player_move)
+                pretty_print_info(info)
+                logger.debug(str(player_move))
+                self.current_player = (self.current_player + 1) % self.table.num_players
+            else:
+                self.disqualify(player_move)
         for move in self.game_history():
             logger.debug(move)
         logger.info('Final score: {score}'.format(score = self.table.score()))
@@ -243,40 +243,19 @@ class HanabiGame:
     def game_history(self):
         return map(lambda action: str(action), self.table.history)
 
-    def is_valid_move(self, player_move):
-        return player_move is not None and (
-            self.is_valid_play_move(player_move) or
-            self.is_valid_discard_move(player_move) or
-            self.is_valid_disclose_move(player_move))
-
-    def is_valid_play_move(self, player_move):
-        return HanabiPlayAction.can_parse_move(player_move)
-
-    def is_valid_discard_move(self, player_move):
-        return HanabiDiscardAction.can_parse_move(player_move) and self.table.can_discard()
-
-    def is_valid_disclose_move(self, player_move):
-        return (self.table.can_disclose() and
-            (HanabiDiscloseColorAction.can_parse_move(player_move) or
-            HanabiDiscloseRankAction.can_parse_move(player_move)))
-
-    def parse_turn(self, player_move):
-        if not self.is_valid_move(player_move):
-            self.disqualify(player_move)
-        move = player_move['play_type']
-        if move == 'play':
-            return self.table.play_card(self.current_player, player_move['card'])
-        elif move == 'discard':
-            return self.table.discard_card(self.current_player, player_move['card'])
-        elif move == 'disclose':
+    def make_move(self, player_move):
+        if isinstance(player_move, moves.HanabiPlayAction):
+            return self.table.play_card(self.current_player, player_move.card)
+        elif isinstance(player_move, moves.HanabiDiscardAction):
+            return self.table.discard_card(self.current_player, player_move.card)
+        elif issubclass(player_move, moves.HanabiDiscloseAction):
             return self.play_disclose(player_move)
 
     def play_disclose(self, player_move):
-        disclose_type = player_move['disclose_type']
-        if disclose_type == 'color':
-            return self.table.disclose_color(self.current_player, player_move['player'], player_move['color'])
-        elif disclose_type == 'rank':
-            return self.table.disclose_rank(self.current_player, player_move['player'], player_move['rank'])
+        if isinstance(player_move, moves.HanabiDiscloseColorAction):
+            return self.table.disclose_color(self.current_player, player_move.player, player_move.color)
+        elif isinstance(player_move, moves.HanabiDiscloseRankAction):
+            return self.table.disclose_rank(self.current_player, player_move.player, player_move.rank)
 
     def disqualify(self, player_move):
         logger.warning('Expected format for play card:')

--- a/sample.sh
+++ b/sample.sh
@@ -1,1 +1,1 @@
-python playgame.py "single" "ai.example_discarder.Discarder" "ai.example_discarder.Discarder" --verbose --log_dir "results/results.txt" --log_stderr "results/errors.txt"
+python playgame.py "single" "ai.example_discarder.Discarder" "ai.example_discarder.Discarder" --log_dir "results/results.txt" --log_stderr "results/errors.txt"

--- a/tools/hanabi_moves.py
+++ b/tools/hanabi_moves.py
@@ -18,16 +18,21 @@ class HanabiCardAction(HanabiAction):
     def __init__(self, player_id, card):
         super(HanabiCardAction, self).__init__(player_id)
         self.card = card
-        self.action_type = ''
+
+    @abc.abstractmethod
+    def action_type(self):
+        pass
 
     def __str__(self):
-        return "Player {id} {action} {card}".format(id = self.player_id, action = self.action_type, card = str(self.card))
+        return "Player {id} {action} {card}".format(id = self.player_id, action = self.action_type(), card = str(self.card))
 
 class HanabiPlayAction(HanabiCardAction):
 
     def __init__(self, player_id, card):
         super(HanabiPlayAction, self).__init__(player_id, card)
-        self.action_type = 'played'
+
+    def action_type(self):
+        return 'played'
 
     def is_valid(self, game_info):
         return True
@@ -38,8 +43,9 @@ class HanabiPlayAction(HanabiCardAction):
 class HanabiDiscardAction(HanabiCardAction):
     def __init__(self, player_id, card):
         super(HanabiDiscardAction, self).__init__(player_id, card)
-        self.action_type = 'discarded'
 
+    def action_type(self):
+        return 'discarded'
 
     def is_valid(self, game_info):
         return game_info.can_discard()
@@ -52,7 +58,13 @@ class HanabiDiscloseAction(HanabiAction):
         super(HanabiDiscloseAction, self).__init__(player_id)
         self.to_whom = to_whom
         self.count = 0
-        self.disclosure_type = ''
+
+    def increment_count(self):
+        self.count += 1
+
+    @abc.abstractmethod
+    def disclosure_type(self):
+        pass
 
     def pluralize(self, word, count):
         if count <= 1:
@@ -74,7 +86,9 @@ class HanabiDiscloseColorAction(HanabiDiscloseAction):
     def __init__(self, player_id, to_whom, color):
         super(HanabiDiscloseColorAction, self).__init__(player_id, to_whom)
         self.color = color
-        self.disclosure_type = self.pluralize(self.color, self.count)
+
+    def disclosure_type(self):
+        return self.pluralize(self.color, self.count)
 
     def is_valid(self, game_info):
         return (super(HanabiDiscloseColorAction, self).is_valid(game_info) and
@@ -87,7 +101,9 @@ class HanabiDiscloseRankAction(HanabiDiscloseAction):
     def __init__(self, player_id, to_whom, rank):
         super(HanabiDiscloseRankAction, self).__init__(player_id, to_whom)
         self.rank = rank
-        self.disclosure_type = self.pluralize(self.rank, self.count)
+
+    def disclosure_type(self):
+        return self.pluralize(self.rank, self.count)
 
     def is_valid(self, game_info):
         return (super(HanabiDiscloseRankAction, self).is_valid(game_info) and

--- a/tools/hanabi_moves.py
+++ b/tools/hanabi_moves.py
@@ -56,9 +56,9 @@ class HanabiDiscloseAction(object):
     def disclosure(self):
         raise Exception('Cannot call superclass implementation of validate')
 
-class HanabiColorDiscloseAction(HanabiDiscloseAction):
+class HanabiDiscloseColorAction(HanabiDiscloseAction):
     def __init__(self, player_id, to_whom, count, color):
-        super(HanabiColorDiscloseAction, self).__init__(player_id, to_whom, count)
+        super(HanabiDiscloseColorAction, self).__init__(player_id, to_whom, count)
         self.color = color
 
     def disclosure(self):
@@ -71,9 +71,9 @@ class HanabiColorDiscloseAction(HanabiDiscloseAction):
         return game_info.can_disclose() and
             self.color in 'RWBGY*'
 
-class HanabiRankDiscloseAction(HanabiDiscloseAction):
+class HanabiDiscloseRankAction(HanabiDiscloseAction):
     def __init__(self, player_id, to_whom, count, rank):
-        super(HanabiRankDiscloseAction, self).__init__(player_id, to_whom, count)
+        super(HanabiDiscloseRankAction, self).__init__(player_id, to_whom, count)
         self.rank = rank
 
     def disclosure(self):

--- a/tools/hanabi_moves.py
+++ b/tools/hanabi_moves.py
@@ -10,6 +10,10 @@ class HanabiAction(object):
     def is_valid(self, game_info):
         pass
 
+    @abc.abstractmethod
+    def execute(self, table):
+        pass
+
 class HanabiCardAction(HanabiAction):
     def __init__(self, player_id, card):
         super(HanabiCardAction, self).__init__(player_id)
@@ -28,6 +32,9 @@ class HanabiPlayAction(HanabiCardAction):
     def is_valid(self, game_info):
         return True
 
+    def execute(self, table):
+        table.play_card(self.player_id, self.card)
+
 class HanabiDiscardAction(HanabiCardAction):
     def __init__(self, player_id, card):
         super(HanabiDiscardAction, self).__init__(player_id, card)
@@ -36,6 +43,9 @@ class HanabiDiscardAction(HanabiCardAction):
 
     def is_valid(self, game_info):
         return game_info.can_discard()
+
+    def execute(self, table):
+        table.discard_card(self.player_id, self.card)
 
 class HanabiDiscloseAction(HanabiAction):
     def __init__(self, player_id, to_whom):
@@ -70,6 +80,9 @@ class HanabiDiscloseColorAction(HanabiDiscloseAction):
         return (super(HanabiDiscloseColorAction, self).is_valid(game_info) and
             self.color in 'RWBGY*')
 
+    def execute(self, table):
+        table.disclose_color(self.player_id, self.to_whom, self.color)
+
 class HanabiDiscloseRankAction(HanabiDiscloseAction):
     def __init__(self, player_id, to_whom, rank):
         super(HanabiDiscloseRankAction, self).__init__(player_id, to_whom)
@@ -79,3 +92,6 @@ class HanabiDiscloseRankAction(HanabiDiscloseAction):
     def is_valid(self, game_info):
         return (super(HanabiDiscloseRankAction, self).is_valid(game_info) and
             self.rank in range(1,6))
+
+    def execute(self, table):
+        table.disclose_rank(self.player_id, self.to_whom, self.rank)

--- a/tools/hanabi_moves.py
+++ b/tools/hanabi_moves.py
@@ -8,10 +8,13 @@ class HanabiCardAction(object):
 
     @classmethod
     def action(self):
-        return "N/A"
+        raise Exception('Cannot call superclass implementation of action')
+
+    def validate(self, game_info):
+        raise Exception('Cannot call superclass implementation of validate')
 
 class HanabiPlayAction(HanabiCardAction):
-    
+
     def __init__(self, player_id, card):
         super(HanabiPlayAction, self).__init__(player_id, card)
 
@@ -23,10 +26,8 @@ class HanabiPlayAction(HanabiCardAction):
     def action(self):
         return "played"
 
-    @staticmethod
-    def can_parse_move(move):
-        return (all(key in move for key in ("play_type", "card")) and
-            move["play_type"] is "play") 
+    def validate(self, game_info):
+        return True
 
 class HanabiDiscardAction(HanabiCardAction):
     def __init__(self, player_id, card):
@@ -36,10 +37,8 @@ class HanabiDiscardAction(HanabiCardAction):
     def action(self):
         return "discarded"
 
-    @staticmethod
-    def can_parse_move(move):
-        return (all(key in move for key in ("play_type", "card")) and
-            move["play_type"] is "discard")
+    def validate(self, game_info):
+        return game_info.can_discard()
 
 class HanabiDiscloseAction(object):
     def __init__(self, player_id, to_whom, count):
@@ -55,25 +54,22 @@ class HanabiDiscloseAction(object):
             disclosure = self.disclosure())
 
     def disclosure(self):
-        return "N/A"
+        raise Exception('Cannot call superclass implementation of validate')
 
 class HanabiColorDiscloseAction(HanabiDiscloseAction):
     def __init__(self, player_id, to_whom, count, color):
         super(HanabiColorDiscloseAction, self).__init__(player_id, to_whom, count)
         self.color = color
-    
+
     def disclosure(self):
         if self.count <= 1:
             return self.color
         else:
             return "{color}s".format(color = self.color)
 
-    @staticmethod
-    def can_parse_move(move):
-        return (all(key in move for key in ("play_type", "player", "disclose_type", "color")) and
-            move["play_type"] is "disclose" and
-            move["disclose_type"] is "color" and
-            move["color"] in "RWBGY*")
+    def validate(self, game_info):
+        return game_info.can_disclose() and
+            self.color in 'RWBGY*'
 
 class HanabiRankDiscloseAction(HanabiDiscloseAction):
     def __init__(self, player_id, to_whom, count, rank):
@@ -86,9 +82,6 @@ class HanabiRankDiscloseAction(HanabiDiscloseAction):
         else:
             return "{rank}s".format(rank = self.rank)
 
-    @staticmethod
-    def can_parse_move(move):
-        return (all(key in move for key in ("play_type", "player", "disclose_type", "rank")) and
-            move["play_type"] is "disclose" and
-            move["disclose_type"] is "rank" and
-            move["rank"] in range (1,6))
+    def validate(self, game_info):
+        return game_info.can_disclose() and
+            self.rank in range(1,6)

--- a/tools/hanabi_moves.py
+++ b/tools/hanabi_moves.py
@@ -1,9 +1,14 @@
+import abc
+
 class HanabiAction(object):
+    __metaclass__ = abc.ABCMeta
+
     def __init__(self, player_id):
         self.player_id = player_id
 
+    @abc.abstractmethod
     def is_valid(self, game_info):
-        raise Exception('Cannot call superclass implementation')
+        pass
 
 class HanabiCardAction(HanabiAction):
     def __init__(self, player_id, card):
@@ -60,7 +65,6 @@ class HanabiDiscloseColorAction(HanabiDiscloseAction):
         super(HanabiDiscloseColorAction, self).__init__(player_id, to_whom)
         self.color = color
         self.disclosure_type = self.pluralize(self.color, self.count)
-
 
     def is_valid(self, game_info):
         return (super(HanabiDiscloseColorAction, self).is_valid(game_info) and

--- a/tools/hanabi_moves.py
+++ b/tools/hanabi_moves.py
@@ -1,87 +1,77 @@
-class HanabiCardAction(object):
-    def __init__(self, player_id, card):
+class HanabiAction(object):
+    def __init__(self, player_id):
         self.player_id = player_id
+
+    def is_valid(self, game_info):
+        raise Exception('Cannot call superclass implementation')
+
+class HanabiCardAction(HanabiAction):
+    def __init__(self, player_id, card):
+        super(HanabiCardAction, self).__init__(player_id)
         self.card = card
+        self.action_type = ''
 
     def __str__(self):
-        return "Player {id} {action} {card}".format(id = self.player_id, action = self.action(), card = str(self.card))
-
-    @classmethod
-    def action(self):
-        raise Exception('Cannot call superclass implementation of action')
-
-    def validate(self, game_info):
-        raise Exception('Cannot call superclass implementation of validate')
+        return "Player {id} {action} {card}".format(id = self.player_id, action = self.action_type, card = str(self.card))
 
 class HanabiPlayAction(HanabiCardAction):
 
     def __init__(self, player_id, card):
         super(HanabiPlayAction, self).__init__(player_id, card)
+        self.action_type = 'played'
 
-    @classmethod
-    def parse_move(self, move):
-        pass
-
-    @classmethod
-    def action(self):
-        return "played"
-
-    def validate(self, game_info):
+    def is_valid(self, game_info):
         return True
 
 class HanabiDiscardAction(HanabiCardAction):
     def __init__(self, player_id, card):
         super(HanabiDiscardAction, self).__init__(player_id, card)
+        self.action_type = 'discarded'
 
-    @classmethod
-    def action(self):
-        return "discarded"
 
-    def validate(self, game_info):
+    def is_valid(self, game_info):
         return game_info.can_discard()
 
-class HanabiDiscloseAction(object):
-    def __init__(self, player_id, to_whom, count):
-        self.player_id = player_id
+class HanabiDiscloseAction(HanabiAction):
+    def __init__(self, player_id, to_whom):
+        super(HanabiDiscloseAction, self).__init__(player_id)
         self.to_whom = to_whom
-        self.count = count
+        self.count = 0
+        self.disclosure_type = ''
+
+    def pluralize(self, word, count):
+        if count <= 1:
+            return word
+        else:
+            return '{word}s'.format(word = word)
 
     def __str__(self):
         return "Player {id} told {whom} about {count} {disclosure} in their hand".format(
             id = self.player_id,
             whom = self.to_whom,
             count = self.count,
-            disclosure = self.disclosure())
+            disclosure = self.disclosure_type)
 
-    def disclosure(self):
-        raise Exception('Cannot call superclass implementation of validate')
+    def is_valid(self, game_info):
+        return game_info.can_disclose()
 
 class HanabiDiscloseColorAction(HanabiDiscloseAction):
-    def __init__(self, player_id, to_whom, count, color):
-        super(HanabiDiscloseColorAction, self).__init__(player_id, to_whom, count)
+    def __init__(self, player_id, to_whom, color):
+        super(HanabiDiscloseColorAction, self).__init__(player_id, to_whom)
         self.color = color
+        self.disclosure_type = self.pluralize(self.color, self.count)
 
-    def disclosure(self):
-        if self.count <= 1:
-            return self.color
-        else:
-            return "{color}s".format(color = self.color)
 
-    def validate(self, game_info):
-        return game_info.can_disclose() and
-            self.color in 'RWBGY*'
+    def is_valid(self, game_info):
+        return (super(HanabiDiscloseColorAction, self).is_valid(game_info) and
+            self.color in 'RWBGY*')
 
 class HanabiDiscloseRankAction(HanabiDiscloseAction):
-    def __init__(self, player_id, to_whom, count, rank):
-        super(HanabiDiscloseRankAction, self).__init__(player_id, to_whom, count)
+    def __init__(self, player_id, to_whom, rank):
+        super(HanabiDiscloseRankAction, self).__init__(player_id, to_whom)
         self.rank = rank
+        self.disclosure_type = self.pluralize(self.rank, self.count)
 
-    def disclosure(self):
-        if self.count <= 1:
-            return self.rank
-        else:
-            return "{rank}s".format(rank = self.rank)
-
-    def validate(self, game_info):
-        return game_info.can_disclose() and
-            self.rank in range(1,6)
+    def is_valid(self, game_info):
+        return (super(HanabiDiscloseRankAction, self).is_valid(game_info) and
+            self.rank in range(1,6))

--- a/tools/hanabi_table.py
+++ b/tools/hanabi_table.py
@@ -135,7 +135,7 @@ class HanabiTable:
         for card in self.hands[to_whom].hand:
             if card.rank == rank:
                 card.disclose_rank()
-                action.count += 1
+                action.increment_count()
         self.history.append(action)
         return action
 
@@ -144,7 +144,7 @@ class HanabiTable:
         action = HanabiDiscloseColorAction(player_id, to_whom, color)
         for card in self.hands[to_whom].hand:
             if card.disclose_color(color, self.is_rainbow_wild):
-                action.count += 1
+                action.increment_count()
         self.history.append(action)
         return action
 

--- a/tools/hanabi_table.py
+++ b/tools/hanabi_table.py
@@ -2,6 +2,7 @@ from hanabi_deck import HanabiDeck, HanabiVariant
 from hanabi_discard_pile import HanabiDiscard
 from hanabi_hand import HanabiHand
 from hanabi_card import HanabiColor
+from hanabi_game_info import GameInfo
 from hanabi_moves import (HanabiPlayAction,
     HanabiDiscardAction,
     HanabiDiscloseRankAction,
@@ -130,22 +131,20 @@ class HanabiTable:
 
     def disclose_rank(self, player_id, to_whom, rank):
         self.disclosures -= 1
-        count = 0
+        action = HanabiDiscloseRankAction(player_id, to_whom, rank)
         for card in self.hands[to_whom].hand:
             if card.rank == rank:
                 card.disclose_rank()
-                count += 1
-        action = HanabiDiscloseRankAction(player_id, to_whom, rank, count)
+                action.count += 1
         self.history.append(action)
         return action
 
     def disclose_color(self, player_id, to_whom, color):
         self.disclosures -= 1
-        count = 0
+        action = HanabiDiscloseColorAction(player_id, to_whom, color)
         for card in self.hands[to_whom].hand:
             if card.disclose_color(color, self.is_rainbow_wild):
-                count += 1
-        action = HanabiDiscloseColorAction(player_id, to_whom, color, count)
+                action.count += 1
         self.history.append(action)
         return action
 

--- a/tools/hanabi_table.py
+++ b/tools/hanabi_table.py
@@ -4,9 +4,8 @@ from hanabi_hand import HanabiHand
 from hanabi_card import HanabiColor
 from hanabi_moves import (HanabiPlayAction,
     HanabiDiscardAction,
-    HanabiRankDiscloseAction,
-    HanabiColorDiscloseAction)
-from hanabi_game_info import GameInfo
+    HanabiDiscloseRankAction,
+    HanabiDiscloseColorAction)
 
 NUM_DISCLOSURES = 8
 NUM_MISTAKES = 3
@@ -136,7 +135,7 @@ class HanabiTable:
             if card.rank == rank:
                 card.disclose_rank()
                 count += 1
-        action = HanabiRankDiscloseAction(player_id, to_whom, rank, count)
+        action = HanabiDiscloseRankAction(player_id, to_whom, rank, count)
         self.history.append(action)
         return action
 
@@ -146,7 +145,7 @@ class HanabiTable:
         for card in self.hands[to_whom].hand:
             if card.disclose_color(color, self.is_rainbow_wild):
                 count += 1
-        action = HanabiColorDiscloseAction(player_id, to_whom, color, count)
+        action = HanabiDiscloseColorAction(player_id, to_whom, color, count)
         self.history.append(action)
         return action
 

--- a/tools/tests/hanabi_game_tests.py
+++ b/tools/tests/hanabi_game_tests.py
@@ -2,6 +2,8 @@ import unittest
 from playgame import HanabiGame
 from argparse import Namespace
 from tools.hanabi_deck import HanabiVariant
+import tools.hanabi_moves as moves
+from tools.hanabi_game_info import GameInfo
 
 def prep_args():
     args = Namespace()
@@ -16,22 +18,16 @@ class HanabiGameTests(unittest.TestCase):
     def setUp(self):
         args = prep_args()
         self.game = HanabiGame(args.players, args.seed, args.variant)
-        self.well_formed_play = {'play_type':'play', 'card':0}
-        self.malformed_play = {'play_type':'play'}
-        self.well_formed_discard = {'play_type':'discard', 'card':0}
-        self.malformed_discard = {}
-        self.well_formed_color_disclose = {'play_type':'disclose', 'player':0, 'disclose_type':'color', 'color':'R'}
-        self.malformed_color_disclose = {'play_type':'disclose', 'player':0, 'disclose_type':'color', 'color':'S'}
-        self.well_formed_rank_disclose = {'play_type':'disclose', 'player':0, 'disclose_type':'rank', 'rank':2}
-        self.malformed_rank_disclose = {'play_type':'disclose', 'player':0, 'disclose_type':'RANK', 'rank':7}
+        self.play = moves.HanabiPlayAction(0, 0)
+        self.discard = moves.HanabiDiscardAction(0, 0)
+        self.disclose_color = moves.HanabiDiscloseColorAction(0, 1, 'R')
+        self.disclose_rank = moves.HanabiDiscloseRankAction(0, 1, 2)
+        self.game_info = GameInfo()
 
     def test_is_valid_move(self):
-        self.game.table.disclose_rank(0, 0, 0)
-        self.assertTrue(self.game.is_valid_move(self.well_formed_play))
-        self.assertFalse(self.game.is_valid_move(self.malformed_play))
-        self.assertTrue(self.game.is_valid_move(self.well_formed_discard))
-        self.assertFalse(self.game.is_valid_move(self.malformed_discard))
-        self.assertTrue(self.game.is_valid_move(self.well_formed_color_disclose))
-        self.assertFalse(self.game.is_valid_move(self.malformed_color_disclose))
-        self.assertTrue(self.game.is_valid_move(self.well_formed_rank_disclose))
-        self.assertFalse(self.game.is_valid_move(self.malformed_rank_disclose))
+        self.game_info.disclosures = 6
+        self.game.table.disclose_rank(0, 0, 1)
+        self.assertTrue(self.play.is_valid(self.game_info))
+        self.assertTrue(self.discard.is_valid(self.game_info))
+        self.assertTrue(self.disclose_color.is_valid(self.game_info))
+        self.assertTrue(self.disclose_rank.is_valid(self.game_info))

--- a/tools/tests/hanabi_move_tests.py
+++ b/tools/tests/hanabi_move_tests.py
@@ -3,43 +3,34 @@ from tools.hanabi_moves import (HanabiDiscardAction,
     HanabiPlayAction,
     HanabiDiscloseColorAction,
     HanabiDiscloseRankAction)
+from tools.hanabi_game_info import GameInfo
 
 class HanabiMoveTests(unittest.TestCase):
 
     def setUp(self):
-        self.well_formed_play = {'play_type':'play', 'card':1}
-        self.malformed_play = {'play_type':'play'}
-        self.well_formed_discard = {'play_type':'discard', 'card':1}
-        self.malformed_discard = {}
-        self.well_formed_color_disclose = {'play_type':'disclose', 'player':0, 'disclose_type':'color', 'color':'R'}
-        self.malformed_color_disclose = {'play_type':'disclose', 'player':0, 'disclose_type':'color', 'color':'S'}
-        self.well_formed_rank_disclose = {'play_type':'disclose', 'player':0, 'disclose_type':'rank', 'rank':2}
-        self.malformed_rank_disclose = {'play_type':'disclose', 'player':0, 'disclose_type':'RANK', 'rank':7}
+        self.play = HanabiPlayAction(0, 1)
+        self.discard = HanabiDiscardAction(0, 1)
+        self.color_disclose = HanabiDiscloseColorAction(0, 1, 'R')
+        self.rank_disclose = HanabiDiscloseRankAction(0, 1, 1)
+        self.game_info = GameInfo()
 
     def test_is_valid_play_move(self):
-        self.assertTrue(HanabiPlayAction.can_parse_move(self.well_formed_play))
-        self.assertFalse(HanabiPlayAction.can_parse_move(self.malformed_play))
-        self.assertFalse(HanabiPlayAction.can_parse_move(self.well_formed_discard))
+        self.assertTrue(self.play.is_valid(self.game_info))
 
     def test_is_valid_discard_move(self):
-        self.assertTrue(HanabiDiscardAction.can_parse_move(self.well_formed_discard))
-        self.assertTrue(HanabiDiscardAction.can_parse_move(self.well_formed_discard))
-        self.assertFalse(HanabiDiscardAction.can_parse_move(self.malformed_discard))
-        self.assertFalse(HanabiDiscardAction.can_parse_move(self.well_formed_play))
+        self.game_info.disclosures = 0
+        self.assertTrue(self.discard.is_valid(self.game_info))
+
+    def test_is_valid_discard_move_cannot_discrd(self):
+        self.game_info.disclosures = 8
+        self.assertFalse(self.discard.is_valid(self.game_info))
 
     def test_is_valid_disclose_move(self):
-        self.assertTrue(HanabiDiscloseColorAction.can_parse_move(self.well_formed_color_disclose))
-        self.assertFalse(HanabiDiscloseColorAction.can_parse_move(self.well_formed_rank_disclose))
-        self.assertFalse(HanabiDiscloseColorAction.can_parse_move(self.malformed_color_disclose))
-        self.assertFalse(HanabiDiscloseColorAction.can_parse_move(self.malformed_rank_disclose))
-        self.assertFalse(HanabiDiscloseColorAction.can_parse_move(self.well_formed_discard))
+        self.game_info.disclosures = 8
+        self.assertTrue(self.color_disclose.is_valid(self.game_info))
+        self.assertTrue(self.rank_disclose.is_valid(self.game_info))
 
-    def test_is_valid_disclose_color(self):
-        self.assertTrue(HanabiDiscloseColorAction.can_parse_move(self.well_formed_color_disclose))
-        self.assertFalse(HanabiDiscloseColorAction.can_parse_move(self.malformed_color_disclose))
-        self.assertFalse(HanabiDiscloseColorAction.can_parse_move(self.well_formed_rank_disclose))
-
-    def test_is_valid_disclose_rank(self):
-        self.assertTrue(HanabiDiscloseRankAction.can_parse_move(self.well_formed_rank_disclose))
-        self.assertFalse(HanabiDiscloseRankAction.can_parse_move(self.malformed_rank_disclose))
-        self.assertFalse(HanabiDiscloseRankAction.can_parse_move(self.well_formed_color_disclose))
+    def test_is_valid_disclose_move_cannot_disclose(self):
+        self.game_info.disclosures = 0
+        self.assertFalse(self.color_disclose.is_valid(self.game_info))
+        self.assertFalse(self.rank_disclose.is_valid(self.game_info))

--- a/tools/tests/hanabi_move_tests.py
+++ b/tools/tests/hanabi_move_tests.py
@@ -1,8 +1,8 @@
 import unittest
 from tools.hanabi_moves import (HanabiDiscardAction,
     HanabiPlayAction,
-    HanabiColorDiscloseAction,
-    HanabiRankDiscloseAction)
+    HanabiDiscloseColorAction,
+    HanabiDiscloseRankAction)
 
 class HanabiMoveTests(unittest.TestCase):
 
@@ -28,18 +28,18 @@ class HanabiMoveTests(unittest.TestCase):
         self.assertFalse(HanabiDiscardAction.can_parse_move(self.well_formed_play))
 
     def test_is_valid_disclose_move(self):
-        self.assertTrue(HanabiColorDiscloseAction.can_parse_move(self.well_formed_color_disclose))
-        self.assertFalse(HanabiColorDiscloseAction.can_parse_move(self.well_formed_rank_disclose))
-        self.assertFalse(HanabiColorDiscloseAction.can_parse_move(self.malformed_color_disclose))
-        self.assertFalse(HanabiColorDiscloseAction.can_parse_move(self.malformed_rank_disclose))
-        self.assertFalse(HanabiColorDiscloseAction.can_parse_move(self.well_formed_discard))
+        self.assertTrue(HanabiDiscloseColorAction.can_parse_move(self.well_formed_color_disclose))
+        self.assertFalse(HanabiDiscloseColorAction.can_parse_move(self.well_formed_rank_disclose))
+        self.assertFalse(HanabiDiscloseColorAction.can_parse_move(self.malformed_color_disclose))
+        self.assertFalse(HanabiDiscloseColorAction.can_parse_move(self.malformed_rank_disclose))
+        self.assertFalse(HanabiDiscloseColorAction.can_parse_move(self.well_formed_discard))
 
     def test_is_valid_disclose_color(self):
-        self.assertTrue(HanabiColorDiscloseAction.can_parse_move(self.well_formed_color_disclose))
-        self.assertFalse(HanabiColorDiscloseAction.can_parse_move(self.malformed_color_disclose))
-        self.assertFalse(HanabiColorDiscloseAction.can_parse_move(self.well_formed_rank_disclose))
+        self.assertTrue(HanabiDiscloseColorAction.can_parse_move(self.well_formed_color_disclose))
+        self.assertFalse(HanabiDiscloseColorAction.can_parse_move(self.malformed_color_disclose))
+        self.assertFalse(HanabiDiscloseColorAction.can_parse_move(self.well_formed_rank_disclose))
 
     def test_is_valid_disclose_rank(self):
-        self.assertTrue(HanabiRankDiscloseAction.can_parse_move(self.well_formed_rank_disclose))
-        self.assertFalse(HanabiRankDiscloseAction.can_parse_move(self.malformed_rank_disclose))
-        self.assertFalse(HanabiRankDiscloseAction.can_parse_move(self.well_formed_color_disclose))
+        self.assertTrue(HanabiDiscloseRankAction.can_parse_move(self.well_formed_rank_disclose))
+        self.assertFalse(HanabiDiscloseRankAction.can_parse_move(self.malformed_rank_disclose))
+        self.assertFalse(HanabiDiscloseRankAction.can_parse_move(self.well_formed_color_disclose))

--- a/tools/tests/playgame_tests.py
+++ b/tools/tests/playgame_tests.py
@@ -11,7 +11,6 @@ class PlayGameparserTests(unittest.TestCase):
     def test_game_simple(self):
         args = ['single', 'Discarder']
         parsed = playgame.parse_args(args)
-        print(parsed)
         self.assertEqual(1, len(parsed.players))
         self.assertEquals(0, parsed.variant)
         self.assertFalse(parsed.verbose)


### PR DESCRIPTION
Resolves #80, #77

Was cleaning up how players implement `do_turn`. Instead of needing to make dictionaries and have `playgame` validate them, now objects are passed that know if they fit the rules of the game or not. Hurray!

### All Submissions:

1. [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
Tacking on changes to existing changes. It's getting a little gross, since I'm merging against myself, but its unique
2. [x] Have you written new tests for new features/fixes for bugs?
Mostly refactoring existing ones. No new tests added

### New Feature Submissions:

1. [x] Does your submission pass tests?
2. [x] Have you linted your code locally prior to submission?

### Changes to Core Features:

1. [ ] Have you written new tests?
2. [x] Have you linted your code locally prior to submission?
3. [x] Have you added an explanation to your changes and why you'd like them included?
4. [x] Does your submission pass tests locally?
